### PR TITLE
Add media types to be able to use as local cache

### DIFF
--- a/buffer.ts.mime
+++ b/buffer.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/buffer_test.ts.mime
+++ b/buffer_test.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/bufio.ts.mime
+++ b/bufio.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/file_server.ts.mime
+++ b/file_server.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/http.ts.mime
+++ b/http.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/http_bench.ts.mime
+++ b/http_bench.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/http_status.ts.mime
+++ b/http_status.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/iotest.ts.mime
+++ b/iotest.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/test.ts.mime
+++ b/test.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/textproto.ts.mime
+++ b/textproto.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/textproto_test.ts.mime
+++ b/textproto_test.ts.mime
@@ -1,0 +1,1 @@
+application/typescript

--- a/util.ts.mime
+++ b/util.ts.mime
@@ -1,0 +1,1 @@
+application/typescript


### PR DESCRIPTION
Fixes an issue blocking denoland/deno#1289.  When treating a set of files like a local cache of dependencies, the `.mime` files need to be provided to ensure that Deno can properly processes the files.