### PR TITLE
Simple file server

### DIFF
--- a/file_server.ts
+++ b/file_server.ts
@@ -1,3 +1,11 @@
+#!/usr/bin/env deno --allow-net
+
+// This program serves files in the current directory over HTTP.
+// TODO Supply the directory to serve as a CLI argument.
+// TODO Stream responses instead of reading them into memory.
+// TODO Add tests like these:
+// https://github.com/indexzero/http-server/blob/master/test/http-server-test.js
+
 import { listenAndServe } from "./http.ts";
 import { cwd, readFile, DenoError, ErrorKind } from "deno";
 

--- a/file_server.ts
+++ b/file_server.ts
@@ -1,18 +1,36 @@
 import { listenAndServe } from "./http.ts";
-import { open, cwd } from "deno";
+import { cwd, readFile, DenoError, ErrorKind } from "deno";
 
 const addr = "0.0.0.0:4500";
-const d = cwd();
+const currentDir = cwd();
 
-listenAndServe(addr, async req => {
-  const filename = d + "/" + req.url;
-  let res;
+const encoder = new TextEncoder();
+
+listenAndServe(addr, async req => {  
+  const fileName = req.url.replace(/\/$/, '/index.html');
+  const filePath = currentDir + fileName;
+  let file;
+
   try {
-    res = { status: 200, body: open(filename) };
+    file = await readFile(filePath);
   } catch (e) {
-    res = { status: 500, body: "bad" };
+    if (e instanceof DenoError && e.kind === ErrorKind.NotFound) {
+      await req.respond({ status: 404, body: encoder.encode("Not found") });  
+    } else {
+      await req.response({ status: 500, body: encoder.encode("Internal server error") });
+    }
+    return;
   }
-  req.respond(res);
+  
+  const headers = new Headers();
+  headers.set('content-type', 'octet-stream');
+
+  const res = {
+    status: 200,
+    body: file,
+    headers,
+  }
+  await req.respond(res);
 });
 
 console.log(`HTTP server listening on http://${addr}/`);

--- a/http.ts
+++ b/http.ts
@@ -82,6 +82,14 @@ export async function* serve(addr: string) {
   listener.close();
 }
 
+export async function listenAndServe(addr: string, handler: (ServerRequest) => void) {
+  const server = serve(addr);
+
+  for await (const request of server) {
+    await handler(request);
+  }
+}
+
 interface Response {
   status?: number;
   headers?: Headers;


### PR DESCRIPTION
If you request path ending with slash (`localhost:4500/foo/bar`) it looks for `index.html` file in that dir.

Ideas for improvement:
- addr option (`-a/--addr 127.0.0.1:4500`)
- serve HTML page with directory structure if `index.html` missing

Closes #9 